### PR TITLE
Fixed the error message thrown when user runs the cloudformation befo…

### DIFF
--- a/aws-auditmanager-assessment/src/main/java/software/amazon/auditmanager/assessment/CreateHandler.java
+++ b/aws-auditmanager-assessment/src/main/java/software/amazon/auditmanager/assessment/CreateHandler.java
@@ -42,7 +42,7 @@ public class CreateHandler extends BaseHandlerStd {
       createAssessmentResponse = proxy.injectCredentialsAndInvokeV2(createAssessmentRequest,
           proxyClient.client()::createAssessment);
     } catch (AwsServiceException e) {
-      throw ExceptionTranslator.translateToCfnException(e, createAssessmentRequest.name());
+      return ExceptionTranslator.translateToCfnException(e, createAssessmentRequest.name());
     }
 
     return ProgressEvent.<ResourceModel, CallbackContext>builder()

--- a/aws-auditmanager-assessment/src/main/java/software/amazon/auditmanager/assessment/DeleteHandler.java
+++ b/aws-auditmanager-assessment/src/main/java/software/amazon/auditmanager/assessment/DeleteHandler.java
@@ -41,7 +41,7 @@ public class DeleteHandler extends BaseHandlerStd {
     try {
       proxy.injectCredentialsAndInvokeV2(deleteAssessmentRequest, proxyClient.client()::deleteAssessment);;
     } catch (AwsServiceException e) {
-      throw ExceptionTranslator.translateToCfnException(e, model.getAssessmentId());
+      return ExceptionTranslator.translateToCfnException(e, model.getAssessmentId());
     }
     return ProgressEvent.defaultSuccessHandler(null);
   }

--- a/aws-auditmanager-assessment/src/main/java/software/amazon/auditmanager/assessment/ListHandler.java
+++ b/aws-auditmanager-assessment/src/main/java/software/amazon/auditmanager/assessment/ListHandler.java
@@ -35,7 +35,7 @@ public class ListHandler extends BaseHandlerStd {
             listAssessmentsResponse = proxy.injectCredentialsAndInvokeV2(listAssessmentsRequest,
                 proxyClient.client()::listAssessments);
         } catch (AwsServiceException e) {
-            throw ExceptionTranslator.translateToCfnException(e, "No identifier specified");
+            return ExceptionTranslator.translateToCfnException(e, "No identifier specified");
         }
 
         request.setNextToken(listAssessmentsResponse.nextToken());

--- a/aws-auditmanager-assessment/src/main/java/software/amazon/auditmanager/assessment/ReadHandler.java
+++ b/aws-auditmanager-assessment/src/main/java/software/amazon/auditmanager/assessment/ReadHandler.java
@@ -41,7 +41,7 @@ public class ReadHandler extends BaseHandlerStd {
           proxyClient.client()::getAssessment);
       logger.log(String.format("%s [%s] retrieved successfully", ResourceModel.TYPE_NAME, model.getAssessmentId()));
     } catch (AwsServiceException e) {
-      throw ExceptionTranslator.translateToCfnException(e, model.getAssessmentId());
+      return ExceptionTranslator.translateToCfnException(e, model.getAssessmentId());
     }
     return ProgressEvent.<ResourceModel, CallbackContext>builder()
         .resourceModel(Utils.transformToAssessmentResourceModel(model, getAssessmentResponse.assessment()))

--- a/aws-auditmanager-assessment/src/test/java/software/amazon/auditmanager/assessment/UpdateHandlerTest.java
+++ b/aws-auditmanager-assessment/src/test/java/software/amazon/auditmanager/assessment/UpdateHandlerTest.java
@@ -1,5 +1,6 @@
 package software.amazon.auditmanager.assessment;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
@@ -19,7 +20,10 @@ import java.time.Duration;
 import com.google.common.collect.Lists;
 import java.util.Date;
 import software.amazon.awssdk.services.auditmanager.AuditManagerClient;
+import software.amazon.awssdk.services.auditmanager.model.AccessDeniedException;
+import software.amazon.awssdk.services.auditmanager.model.CreateAssessmentRequest;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
@@ -184,6 +188,31 @@ public class UpdateHandlerTest extends AbstractTestBase {
   }
 
   @Test
+  public void testUpdateAssessment_withoutRegistration_shouldThrowAccessDenied() {
+    final ResourceModel previousResourceModel =
+        Utils.transformToAssessmentResourceModel(makeResourceModel(), makeAssessment(null, null));
+    final ResourceModel currentResourceModel =
+        Utils.transformToAssessmentResourceModel(makeResourceModel(), makeAssessment(null, null));
+    currentResourceModel.getRoles().get(0).setRoleArn(USER_ARN_UPDATED);
+
+    final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+        .desiredResourceState(currentResourceModel)
+        .previousResourceState(previousResourceModel)
+        .build();
+
+    when(proxyClient.client().updateAssessment(any(UpdateAssessmentRequest.class)))
+        .thenThrow(
+            AccessDeniedException.builder().message(ExceptionTranslator.AUDIT_MANAGER_NOT_ENABLED_MESSAGE).build());
+    final ProgressEvent<ResourceModel, CallbackContext> response =
+        handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+    assertThat(response).isNotNull();
+    assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+    assertThat(response.getMessage()).isEqualTo(ExceptionTranslator.AUDIT_MANAGER_NOT_ENABLED_MESSAGE);
+    assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.AccessDenied);
+
+  }
+
+  @Test
   public void testUpdateAssessment_completedAssessment_shouldThrowInvalidRequest() {
     final ResourceModel previousResourceModel =
         Utils.transformToAssessmentResourceModel(makeResourceModel(), makeAssessment(null, null));
@@ -213,12 +242,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         .desiredResourceState(currentResourceModel)
         .previousResourceState(previousResourceModel)
         .build();
-
-    currentResourceModel.setAssessmentId("test");
-    assertThrows(CfnNotUpdatableException.class, () ->
-        handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
-
-    currentResourceModel.setAssessmentId(previousResourceModel.getAssessmentId());
 
     currentResourceModel.setFrameworkId("test");
     assertThrows(CfnNotUpdatableException.class, () ->


### PR DESCRIPTION
*Issue*
If user created a assessment using cloudformation before enabling audit manager then the error message is not useful.

*Description of changes:*
Changed the code to return the clear error message "Please complete AWS Audit Manager setup from home page to enable this action in this account" when audit manager is not enabled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
